### PR TITLE
feat(package.json): add support for node 17+

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "webpack-cli": "^3.3.12"
   },
   "scripts": {
-    "webpack-dev": "webpack --mode=development --watch",
-    "webpack": "webpack --mode=production",
+    "webpack-dev": "export SET NODE_OPTIONS=--openssl-legacy-provider && webpack --mode=development --watch",
+    "webpack": "export SET NODE_OPTIONS=--openssl-legacy-provider && webpack --mode=production",
     "tsc": "tsc",
     "tsc-dev": "tsc --watch"
   }


### PR DESCRIPTION
Add support for node 17+ by adding the --openssl-legacy-provider flag to the webpack-dev and webpack scripts.